### PR TITLE
Fix NPE on ModbusReq instance destroy

### DIFF
--- a/modbus4android/src/main/java/com/zgkxzx/modbus4And/requset/ModbusReq.java
+++ b/modbus4android/src/main/java/com/zgkxzx/modbus4And/requset/ModbusReq.java
@@ -119,7 +119,9 @@ public class ModbusReq {
      */
     public void destory() {
         modbusReq = null;
-        mModbusMaster.destroy();
+        if (mModbusMaster != null) {
+            mModbusMaster.destroy();
+        }
         isInit = false;
     }
 


### PR DESCRIPTION
This NPE may occure when we attemp to destroy a ModbusReq instance whithout initializing it before. It may happen for example if Modbus is optionnaly used in an app and not initialized, but destroyed when the app is closed.